### PR TITLE
Add dummy project ID to datastore start command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,4 +43,4 @@ EXPOSE 8082
 
 
 # Set the default command to run when starting the container
-CMD ["/bin/bash", "-c", "gcloud beta emulators datastore start   --no-store-on-disk    --host-port 0.0.0.0:8082"]
+CMD ["/bin/bash", "-c", "gcloud beta emulators datastore start --project=cbio-local-dev-project  --no-store-on-disk    --host-port 0.0.0.0:8082"]


### PR DESCRIPTION
## What
Add in a dummy project ID to datastore start command.

## Why
See slack conversation here: https://cerebrae.slack.com/archives/C35CVFZU0/p1580227727001200

## Testing
- Locally build (`docker build . -t test-image`) then run (` docker run -it --rm -p 8082:8082 test-image`)
- Pushed image to container registry ([here](https://console.cloud.google.com/gcr/images/cbio-cicd/GLOBAL/cerebrae/google/cloud-sdk-docker@sha256:0fefbade70b0a8b6b8b27852aba0b450f143e7482f9adc8e05021b1f7288b908/details?tab=info&project=cbio-cicd&organizationId=809230094658)), and confirmed build using this image passes (ref: https://console.cloud.google.com/cloud-build/builds/0738e5a5-6d52-4c3f-97af-a0bc917972a4?project=cbio-cicd)